### PR TITLE
FIX: Broken links on "new-color-scheme-roles.md" page

### DIFF
--- a/src/content/release/breaking-changes/new-color-scheme-roles.md
+++ b/src/content/release/breaking-changes/new-color-scheme-roles.md
@@ -154,7 +154,7 @@ Relevant PRs:
 * [Enhance ColorScheme.fromSeed with a new variant parameter][]
 
 [Support tone-based surface and surface container ColorScheme roles]: {{site.repo.flutter}}/issues/115912
-[Support fidelity variant for ColorScheme.fromSeed]: {{site.repo.flutter}}/issues/[144649]
-[Introduce tone-based surfaces and accent color add-ons - Part 1]: {{site.repo.flutter}}/pull/[142654]
-[Introduce tone-based surfaces and accent color add-ons - Part 2]: {{site.repo.flutter}}/pull/[144273]
-[Enhance ColorScheme.fromSeed with a new variant parameter]: {{site.repo.flutter}}/pull/[144805]
+[Support fidelity variant for ColorScheme.fromSeed]: {{site.repo.flutter}}/issues/144649
+[Introduce tone-based surfaces and accent color add-ons - Part 1]: {{site.repo.flutter}}/pull/142654
+[Introduce tone-based surfaces and accent color add-ons - Part 2]: {{site.repo.flutter}}/pull/144273
+[Enhance ColorScheme.fromSeed with a new variant parameter]: {{site.repo.flutter}}/pull/144805


### PR DESCRIPTION
The following four links to reference pages on the Flutter web site page https://docs.flutter.dev/release/breaking-changes/new-color-scheme-roles are broken:

- [Support fidelity variant for ColorScheme.fromSeed](https://github.com/flutter/flutter/issues/144649)
- [Introduce tone-based surfaces and accent color add-ons - Part 1](https://github.com/flutter/flutter/pull/142654)
- [Introduce tone-based surfaces and accent color add-ons - Part 2](https://github.com/flutter/flutter/pull/138521)
- [Enhance ColorScheme.fromSeed with a new variant parameter](https://github.com/flutter/flutter/pull/144805)

They are broken due to wrong syntax in the markdown file, used URLs are otherwise correct, but the used extended markdown link syntax is not, causing the links to be broken.

This PR fixes the error so the links work.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
